### PR TITLE
[Feat] 결과창 바텀 시트 종교성 여부 추가

### DIFF
--- a/E-NAME/E-NAME.xcodeproj/project.pbxproj
+++ b/E-NAME/E-NAME.xcodeproj/project.pbxproj
@@ -148,9 +148,9 @@
 				8EC091F92858FA82006B3DAE /* FirstViewController.swift */,
 				8EC091FC2858FADA006B3DAE /* SecondViewController.swift */,
 				8EC091FE2858FAE1006B3DAE /* ThirdViewController.swift */,
+				8E6D4D7F285E4FDB00536898 /* WaitingViewController.swift */,
 				8E4D56DE285E2A7D0020F018 /* ResultViewController.swift */,
 				8E4EE046285E4BEB00771FD3 /* BottomViewController.swift */,
-				8E6D4D7F285E4FDB00536898 /* WaitingViewController.swift */,
 			);
 			path = Survey;
 			sourceTree = "<group>";

--- a/E-NAME/E-NAME/Source/Screen/Survey/BottomViewController.swift
+++ b/E-NAME/E-NAME/Source/Screen/Survey/BottomViewController.swift
@@ -13,6 +13,7 @@ class BottomViewController: UIViewController {
     var englishMeaning: String?
     var koreanMeaning: String?
     var genderMeaning: String?
+    var religion: Bool?
     
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var detailLabel: UILabel!
@@ -35,10 +36,13 @@ class BottomViewController: UIViewController {
         guard let name = name,
               let englishMeaning = englishMeaning,
               let koreanMeaning = koreanMeaning,
-              let genderMeaning = genderMeaning else { return }
+              let genderMeaning = genderMeaning,
+              let religion = religion else { return }
+        
+        let religions = religion ? "O" : "X"
         
         nameLabel.text = name
-        detailLabel.text = "영어 뜻 : " + englishMeaning + "\n한글 뜻 : " + koreanMeaning + "\n성별 : " + genderMeaning
+        detailLabel.text = "영어 뜻 : " + englishMeaning + "\n한글 뜻 : " + koreanMeaning + "\n성별 : " + genderMeaning + "\n종교여부 : " + religions
     }
 }
 

--- a/E-NAME/E-NAME/Source/Screen/Survey/Result.storyboard
+++ b/E-NAME/E-NAME/Source/Screen/Survey/Result.storyboard
@@ -533,43 +533,43 @@
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="TD1-bh-rRE">
-                                        <rect key="frame" x="20" y="189.33333333333331" width="275" height="111"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="TD1-bh-rRE">
+                                        <rect key="frame" x="20" y="189.33333333333331" width="275" height="142.33333333333331"/>
                                         <attributedString key="attributedText">
                                             <fragment content="영어 뜻 : 한글 ">
                                                 <attributes>
-                                                    <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" metaFont="system" size="17"/>
+                                                    <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" lineSpacing="25" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
                                             <fragment content="뜻">
                                                 <attributes>
-                                                    <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" metaFont="system" size="17"/>
+                                                    <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
                                                     <font key="NSOriginalFont" metaFont="system" size="17"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" lineSpacing="25" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
                                             <fragment content=" :  ">
                                                 <attributes>
-                                                    <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" metaFont="system" size="17"/>
+                                                    <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" lineSpacing="25" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
                                             <fragment content="성별">
                                                 <attributes>
-                                                    <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" metaFont="system" size="17"/>
+                                                    <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
                                                     <font key="NSOriginalFont" metaFont="system" size="17"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" lineSpacing="25" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
-                                            <fragment content=" :">
+                                            <fragment content=" : 종교여부 :">
                                                 <attributes>
-                                                    <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" metaFont="system" size="17"/>
+                                                    <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="truncatingTail" baseWritingDirection="natural" lineSpacing="25" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>

--- a/E-NAME/E-NAME/Source/Screen/Survey/ResultViewController.swift
+++ b/E-NAME/E-NAME/Source/Screen/Survey/ResultViewController.swift
@@ -49,6 +49,7 @@ class ResultViewController: UIViewController {
         bottomVC.englishMeaning = nameData?.mean.components(separatedBy: "@")[0]
         bottomVC.koreanMeaning = nameData?.mean.components(separatedBy: "@")[1]
         bottomVC.genderMeaning = genderString
+        bottomVC.religion = nameData?.christianity
 
         bottomVC.modalTransitionStyle = .crossDissolve
         bottomVC.modalPresentationStyle = .overFullScreen
@@ -71,7 +72,7 @@ class ResultViewController: UIViewController {
             break
         }
         nameLabel.text = nameData?.name
-        detailLabel.text = "뜻 : " + (nameData?.mean.replacingOccurrences(of: "@", with: "\n     ") ?? "") + "\n성별 : " + genderString
+        detailLabel.text = "뜻 : " + (nameData?.mean.replacingOccurrences(of: "@", with: "\n      ") ?? "") + "\n성별 : " + genderString
     }
     
     @IBAction func homeButtonTapped(_ sender: Any) {


### PR DESCRIPTION
`시뮬레이터 (iPhone 13 mini)`
| `결과창` | `자세히 보기` |
| :---: | :---: |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-06-20 at 14 19 48](https://user-images.githubusercontent.com/80062632/174530362-3daee157-ade1-4555-9481-87d02c520023.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-06-20 at 14 19 52](https://user-images.githubusercontent.com/80062632/174530373-bf35bafa-2518-4da5-a4fe-67683d69413b.png) |





